### PR TITLE
Support for `kuvert` encrypted e-mails; removal of unnecessary `ports` stanzas

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,6 +9,11 @@ networks:
   id2internal:
     driver: bridge
 
+  # for kuvert-supported encrypted/signed e-mails
+  postar_default:
+    external:
+      name: postar_default
+
 services:
   postgres:
     image: postgres:9.4
@@ -41,6 +46,7 @@ services:
       - postgres
     networks:
       - id2internal
+      - postar_default
 
   web:
     image: nginx:alpine

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -38,8 +38,6 @@ services:
       - "/srv/data/live/idstatic/:/id/build/"
     env_file:
       - id.env
-    ports:
-      - "8080:8080"
     depends_on:
       - postgres
     links:
@@ -52,8 +50,8 @@ services:
     image: nginx:alpine
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf
-    ports:
-      - "8000:8000"
+    expose:
+     - 8000
     depends_on:
       - api
     networks:


### PR DESCRIPTION
Added a `postar_default` network to the `docker-compose.prod.yml` so that ID can communicate with `kuvert` processes, which handle encrypting and signing e-mails.

While at it, removed the unnecessary `ports` stanzas from `docker-compose.prod.yml`, since the `api` container is served via `web` (so, no need to expose `api` at all), and `web` goes through `serverconfig_frontend` network anyway, so no need to expose its port to the host interface.