### PR TITLE
Extend the search to include comments

### DIFF
--- a/api_v3/models/ticket.py
+++ b/api_v3/models/ticket.py
@@ -49,6 +49,10 @@ class Ticket(models.Model):
         'first_name': 'A',
         'last_name': 'A',
         'company_name': 'A',
+        'comments__body': 'A',
+        'comments__user__email': 'A',
+        'comments__user__first_name': 'A',
+        'comments__user__last_name': 'A',
         'background': 'B',
         'connections': 'C',
         'sources': 'C',
@@ -161,4 +165,4 @@ class Ticket(models.Model):
             rank=SearchRank(vector, query)
         ).filter(
             rank__gte=cls.MIN_SEARCH_RANK
-        ).order_by('rank')
+        ).distinct().order_by('rank')

--- a/api_v3/tests/models/test_filter_by_models.py
+++ b/api_v3/tests/models/test_filter_by_models.py
@@ -129,6 +129,12 @@ class TicketAttachmentCommentFilterByUserRequesterTestCase(
         tickets = Ticket.search_for('fname', Ticket.objects.none())
         self.assertEqual(tickets.count(), 0)
 
+    def test_tickets_search_for_comments(self):
+        tickets = Ticket.search_for('body1')
+
+        self.assertEqual(tickets.count(), 1)
+        self.assertIn(self.tickets[0], tickets)
+
     def test_attachment_filter_by_user(self):
         attachments = Attachment.filter_by_user(self.users[0])
 


### PR DESCRIPTION
The main search functionality was already implemented. What I did was extending the existing SearchVector with some attributes from the `comments` and `profile` model:

- `comments__body`
- `comments__user__first_name`
- `comments__user__last_name` 
- `comments__user__email`.

All new vectors got the weight `A` (because it was not specified which weight they should have). I also added a `distinct()` to the search query to avoid duplicates in the query result.

With this approach two new joins where introduced in the query. I did some performance measurements with an empty and with an lightly filled database and I didn't see any performance issues so far. I guess it depends how much data are in the specific tables.

This task was straight forward and I didn't need much time for it. I also added one test to the model tests.